### PR TITLE
fix: adjust t3 version for cms-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require": {
 		"typo3/cms-backend": "^13.0 || 13.*.*@dev || ^14.0 || 14.*.*@dev || dev-main",
-		"typo3/cms-core": "^13.1",
+		"typo3/cms-core": "^13.1 || ^14.0 || 14.*.*@dev || dev-main",
 		"b13/container": "^3.1.4 || dev-master"
 	},
 	"require-dev": {


### PR DESCRIPTION
Hi!

Currently its not possible to install this version on v14, because of the `cms-core` requirement.
This should fix it.

Thanks again!